### PR TITLE
Line up input and output

### DIFF
--- a/app/index.css
+++ b/app/index.css
@@ -137,9 +137,10 @@ label::after {
 }
 
 .app__output p {
-    margin: 0px 0px 14px 0;
+    margin: 0;
     font-weight: 900;
     cursor: pointer;
+    height: 1.1875rem;
 }
 
 .app__body {
@@ -155,6 +156,7 @@ label::after {
     font-size: 0.8rem;
     font-weight: 900;
     letter-spacing: 1px;
+    line-height: 1.1875rem;
 }
 
 .app__input {
@@ -164,6 +166,7 @@ label::after {
     background: transparent;
     resize: none;
     width: 100%;
+    overflow: hidden;
 }
 
 .app__output {


### PR DESCRIPTION
Closes #22 

- Removed 14px margin causing the misalignment
- Added a height for all `p` elements so blank lines in the output (comments) get space as well
- Added `overflow: hidden` to the input so we're not getting a separate scrollbar

<img width="140" alt="Screen Shot 2019-10-02 at 4 36 02 PM" src="https://user-images.githubusercontent.com/17421347/66089793-8d68e500-e535-11e9-8495-736eb7c03453.png">
