### PR TITLE
Wrap selected text in parentheses when the '(' key is typed.

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -1,67 +1,74 @@
 <!DOCTYPE html>
 <html>
-	<head>
-		<meta charset="utf-8" />
-		<title>Caligator</title>
-		<script>
-			window.loadTheme = () => {
-				let userTheme = localStorage.userTheme;
-				let OSTheme = localStorage.osTheme;
-				let defaultTheme = 'auto';
-				if (userTheme === 'auto' || !userTheme) {
-					document.documentElement.setAttribute(
-						'data-theme',
-						OSTheme
-					);
-				} else {
-					document.documentElement.setAttribute(
-						'data-theme',
-						userTheme
-					);
-				}
-			};
-			loadTheme();
-		</script>
-		<link rel="stylesheet" href="index.css" />
-	</head>
 
-	<body>
-		<div class="modal">
-			<header class="modal__head">
-				<h1 class="modal__title">More</h1>
-				<div class="modal__controls">
-					<i id="modal__popup--close" class="icon icon--close"></i>
-				</div>
-			</header>
-			<div class="modal__body">
-				<label for="theme-switcher">Theme</label>
+<head>
+    <meta charset="utf-8" />
+    <title>Caligator</title>
+    <script>
+        window.loadTheme = () => {
+            let userTheme = localStorage.userTheme;
+            let OSTheme = localStorage.osTheme;
+            let defaultTheme = 'auto';
+            if (userTheme === 'auto' || !userTheme) {
+                document.documentElement.setAttribute(
+                    'data-theme',
+                    OSTheme
+                );
+            } else {
+                document.documentElement.setAttribute(
+                    'data-theme',
+                    userTheme
+                );
+            }
+        };
+        loadTheme();
 
-				<select id="theme-switcher">
-					<option value="auto" selected>Auto</option>
-					<option value="dark">Dark Mode</option>
-					<option value="light">Light Mode</option>
-				</select>
-			</div>
-		</div>
+    </script>
+    <link rel="stylesheet" href="index.css" />
+</head>
 
-		<header class="app__head">
-			<div class="app__controls">
-				<i id="app--settings" class="icon icon--settings"></i>
-			</div>
-			<h1 class="app__title">Caligator</h1>
-			<div class="app__controls">
-				<i id="app--minimize" class="icon icon--minimize"></i>
-				<i id="app--close" class="icon icon--close"></i>
-			</div>
-		</header>
+<body>
+    <div class="modal">
+        <header class="modal__head">
+            <h1 class="modal__title">More</h1>
+            <div class="modal__controls">
+                <i id="modal__popup--close" class="icon icon--close"></i>
+            </div>
+        </header>
+        <div class="modal__body">
+            <label for="theme-switcher">Theme</label>
 
-		<section class="app__container">
-			<div class="app__body">
-				<textarea class="app__input" autofocus="true"></textarea>
-				<div class="app__output"></div>
-			</div>
-		</section>
+            <select id="theme-switcher">
+                <option value="auto" selected>Auto</option>
+                <option value="dark">Dark Mode</option>
+                <option value="light">Light Mode</option>
+            </select>
 
-		<script src="script.js"></script>
-	</body>
+            <hr />
+            <label for="toggle-paren-wrap">Wrap selected text with parentheses</label>
+            <input type="checkbox" id="toggle-paren-wrap">
+        </div>
+    </div>
+
+    <header class="app__head">
+        <div class="app__controls">
+            <i id="app--settings" class="icon icon--settings"></i>
+        </div>
+        <h1 class="app__title">Caligator</h1>
+        <div class="app__controls">
+            <i id="app--minimize" class="icon icon--minimize"></i>
+            <i id="app--close" class="icon icon--close"></i>
+        </div>
+    </header>
+
+    <section class="app__container">
+        <div class="app__body">
+            <textarea class="app__input" autofocus="true"></textarea>
+            <div class="app__output"></div>
+        </div>
+    </section>
+
+    <script src="script.js"></script>
+</body>
+
 </html>

--- a/app/script.js
+++ b/app/script.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { remote } = require('electron');
+const { keyboardState, keys, overrideShift } = require('../utils/keyboard');
 const main = require('../utils/main');
 
 // By default OS theme
@@ -54,6 +55,30 @@ inputContainer.addEventListener('keyup', e => {
 });
 
 /**
+ * @event
+ * Updates the 'shift' key state.
+ */
+inputContainer.addEventListener('keyup', e => {
+	if (e.key === keys.SHIFT) {
+		keyboardState.shift = false;
+	}
+});
+
+/**
+ * @event
+ * This adds some functionality when the shift key is pressed.
+ */
+inputContainer.addEventListener('keydown', e => {
+	const { key } = e;
+	// toggle the shift key
+	if (key === keys.SHIFT) {
+		keyboardState.shift = true;
+	} else if (keyboardState.shift) {
+		overrideShift(key);
+	}
+});
+
+/**
  * This function passes the data and updates the result on the markup
  * @param {Array} arr - gets the expression by line as an array
  * @private
@@ -79,7 +104,7 @@ const appPopup = document.querySelectorAll('.modal')[0];
  * This function adds the window controls to the application
  * @private
  */
-(function() {
+(function () {
 	const { BrowserWindow } = require('electron').remote;
 
 	function init() {

--- a/utils/keyboard.js
+++ b/utils/keyboard.js
@@ -29,7 +29,7 @@ const overrideShift = (key) => {
 
   // do this if 
   if (selection.length > 0) {
-    if (key === keys.OPEN_PARENTHESIS) {
+    if (key === keys.OPEN_PARENTHESIS && document.getElementById('toggle-paren-wrap').checked) {
 
       // don't replace the text
       event.preventDefault();

--- a/utils/keyboard.js
+++ b/utils/keyboard.js
@@ -24,22 +24,22 @@ const keyboardState = {
 };
 
 const overrideShift = (key) => {
-  // get the selected text
+  // Get the selected text
   const selection = window.getSelection().toString();
 
-  // do this if 
+  // Do this if there is a) selected text and b) wrapping is enabled
   if (selection.length > 0) {
     if (key === keys.OPEN_PARENTHESIS && document.getElementById('toggle-paren-wrap').checked) {
 
-      // don't replace the text
+      // Don't replace the text...
       event.preventDefault();
 
-      // wrap in parenthesis. Use document.execCommand to make the opperation undoable
+      // ...wrap in parenthesis. Use document.execCommand to make the opperation undoable
       const { selectionStart, selectionEnd } = document.activeElement;
       const selection = document.getSelection().toString();
       document.execCommand(commands.INSERT_TEXT, false, `(${selection})`);
 
-      // reselect the text
+      // Reselect the text
       document.activeElement.selectionStart = selectionStart;
       document.activeElement.selectionEnd = selectionEnd + 2;
     }

--- a/utils/keyboard.js
+++ b/utils/keyboard.js
@@ -1,0 +1,54 @@
+/**
+ * Constants to map to keyboard Event keys
+ * @type {Object}
+ */
+const keys = {
+  SHIFT: 'Shift',
+  OPEN_PARENTHESIS: '('
+};
+
+/**
+ * Constants to map to the document.executeCommand function.
+ * @type {Object}
+ */
+const commands = {
+  INSERT_TEXT: 'insertText'
+};
+
+/**
+ * A simple object to track some keyboard state.
+ * @type {Object}
+ */
+const keyboardState = {
+  shift: false
+};
+
+const overrideShift = (key) => {
+  // get the selected text
+  const selection = window.getSelection().toString();
+
+  // do this if 
+  if (selection.length > 0) {
+    if (key === keys.OPEN_PARENTHESIS) {
+
+      // don't replace the text
+      event.preventDefault();
+
+      // wrap in parenthesis. Use document.execCommand to make the opperation undoable
+      const { selectionStart, selectionEnd } = document.activeElement;
+      const selection = document.getSelection().toString();
+      document.execCommand(commands.INSERT_TEXT, false, `(${selection})`);
+
+      // reselect the text
+      document.activeElement.selectionStart = selectionStart;
+      document.activeElement.selectionEnd = selectionEnd + 2;
+    }
+  }
+}
+
+module.exports = {
+  keys,
+  keyboardState,
+  commands,
+  overrideShift
+};


### PR DESCRIPTION
You know how in VS Code (and most other modern editors) you can select text and wrap it with brackets, quotes, etc., so `text selected_text` becomes `text "selected_text"`? I added that for parentheses. It's disabled by default but I added a little checkbox to the menu to toggle the feature. 

_Feedback appreciated_