### PR TITLE
Bring back temperature, percentage and ratio conversion

### DIFF
--- a/utils/coreConv.js
+++ b/utils/coreConv.js
@@ -84,6 +84,8 @@ const convert = (mode, value, oldUnit, newUnit) => {
 			return convertRatio(value, oldUnit, newUnit);
 		case 'p':
 			return convertPercent(value, oldUnit, newUnit);
+		default:
+			''
 	}
 };
 
@@ -109,7 +111,6 @@ const convertRatio = (ratio, ofValue) => {
 const convertPercent = (percent, _, ofValue) => {
 	return (percent / 100) * ofValue;
 };
-
 
 /**
  * This is a function to perform weight conversion

--- a/utils/main.js
+++ b/utils/main.js
@@ -20,6 +20,9 @@ const textForOperators = {
 };
 
 /** @const {string} */
+const temperatureUnits = coreConv.temperatureUnits.join('|');
+
+/** @const {string} */
 const currencyUnits = Object.keys(coreConv.currencyUnits).join('|');
 
 /** @const {object} */
@@ -39,7 +42,16 @@ const generateRegExpForUnits = units =>
 	);
 
 /** @const {object} */
+const temperatureRegExp = generateRegExpForUnits(temperatureUnits);
+
+/** @const {object} */
 const currencyRegExp = generateRegExpForUnits(currencyUnits);
+
+/** @const {object} */
+const percentageRegExp = new RegExp(/(\d+)\s*(%\s*of)\s*(\d+)/, 'm');
+
+/** @const {object} */
+const ratioRegExp = new RegExp(/(\d+\/\d+)\s*of\s*(\d+)/, 'm');
 
 /**
  * This function filters the given value with
@@ -85,8 +97,20 @@ const evaluate = exp => {
 		exp = exp.replace(operatorRegExp, textForOperators[operator]);
 	});
 
+	if (temperatureRegExp.test(exp)) {
+		return parseExp(exp, temperatureRegExp, 't');
+	}
+
 	if (currencyRegExp.test(exp.toUpperCase())) {
 		return parseExp(exp.toUpperCase(), currencyRegExp, 'c');
+	}
+
+	if (percentageRegExp.test(exp)) {
+		return parseExp(exp, percentageRegExp, 'p');
+	}
+
+	if (ratioRegExp.test(exp)) {
+		return parseExp(exp, ratioRegExp, 'r');
 	}
 
 	return mathJs.evaluate(exp);

--- a/utils/main.test.js
+++ b/utils/main.test.js
@@ -1,0 +1,38 @@
+const assert = require('assert');
+const { describe, it } = require('mocha');
+
+const main = require('./main');
+
+describe('evaluate', () => {
+	it('should correctly evaluate a comment', () => {
+		assert.strictEqual(main.evaluate('#500g to kg'), '');
+	});
+
+	it('should correctly evaluate weight conversion', () => {
+		assert.strictEqual(main.evaluate('500g to kg'), '0.5 kg');
+	});
+
+	it('should correctly evaluate length conversion', () => {
+		assert.strictEqual(main.evaluate('500cm to m'), '0.5 m');
+	});
+
+	it('should correctly evaluate temperature conversion', () => {
+		assert.strictEqual(main.evaluate('100c to f'), '212');
+	});
+
+	it('should correctly evaluate currency conversion', () => {
+		assert.strictEqual(main.evaluate('1 usd to eur'), '0.91');
+	});
+
+	it('should correctly evaluate a percentage', () => {
+		assert.strictEqual(main.evaluate('30% of 1'), '0.3');
+	});
+
+	it('should correctly evaluate a ratio', () => {
+		assert.strictEqual(main.evaluate('1/2 of 3'), '1.5');
+	});
+
+	it('returns empty string when the expression cannot be parsed', () => {
+		assert.strictEqual(main.evaluate('unparsable'), 'sadf');
+	});
+});


### PR DESCRIPTION
It seems 094d8f692aef80fb34b11acee729b967db1682e7 took out temperature, percentage and ratio conversion which are not part of mathjs, so I'm bringing the logic back in.